### PR TITLE
Fix #3.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,23 +3,37 @@
 const FPEEncryptor = require('./lib/fpe_encryptor');
 const factor = require('./lib/factor');
 const assureBigInt = require('./lib/assureBigInt');
+const round = require('./lib/round');
 
 
 module.exports = {
 	/**
-	 * Generic Z_n FPE encryption, FE1 scheme
+	 * Returns the number of rounds encrypt/decrypt will perform.
 	 *
-	 * @param {number} modulus - Use to determine the range of the numbers. Example, if the numbers range from 0 to 999, use "1000" here
+	 * @return {number} The current number of rounds.
+	 */
+	getRound: round.getRound,
+	/**
+	 * Sets the of number rounds for encrypt/decypt methods.
+	 *
+	 * @param {number} round - The current number of rounds.
+	 * @throws If parameter round is not an integer or it is less than 1.
+	 */
+	setRound: round.setRound,
+	/**
+	 * Generic Z_n FPE encryption, FE1 scheme.
+	 *
+	 * @param {number} modulus - Use to determine the range of the numbers. Example, if the numbers range from 0 to 999, use "1000" here.
 	 * @param {number} subject - The number to encrypt. Must be < modulus.
-	 * @param {string} key - key Secret key to encrypt with. Must be compatible with HMAC(SHA256).  See https://tools.ietf.org/html/rfc2104#section-3 for recommendations,
-	 * on key length and generation.  Anything over 64 bytes is hashed to a 64 byte value, 32 bytes is generally considered "good enough" for most applications.
+	 * @param {string} key - Secret key to encrypt with. Must be compatible with HMAC(SHA256). See https://tools.ietf.org/html/rfc2104#section-3 for recommendations,
+	 * on key length and generation. Anything over 64 bytes is hashed to a 64 byte value, 32 bytes is generally considered "good enough" for most applications.
 	 * @param {string} tweak - Non-secret parameter, think of it as an initialisation vector. Must be non-null and at least 1 byte long, no upper limit.
-	 * @return {number} the encrypted version of <code>subject</code>.
+	 * @return {number} The encrypted version of <code>subject</code>.
 	 */
 	encrypt(modulus, subject, key, tweak) {
 		modulus = assureBigInt(modulus);
 		const cipher = new FPEEncryptor(key, modulus, tweak);
-		const rounds = 3;
+		const rounds = this.getRound();
 		const [firstFactor, secondFactor] = factor(modulus);
 
 		let right;
@@ -34,16 +48,17 @@ module.exports = {
 	},
 	/**
 	 * Generic Z_n FPE decryption, FE1 scheme.
+	 *
 	 * @param {number} modulus - Use to determine the range of the numbers. Example, if the numbers range from 0 to 999, use "1000" here.
 	 * @param {number} cryptedSubject - The number to decrypt. Must be < modulus.
 	 * @param {string|buffer} key - String or Buffer representing the secret key, must be compatible with HMAC(SHA256).
 	 * @param {string|buffer} tweak - String or Buffer representing non-secret parameter, think of it as an IV - use the same one used to encrypt. Must be non-null and non-zero length.
-	 * @return {number} The decrypted number
+	 * @return {number} The decrypted number.
 	 */
 	decrypt(modulus, cryptedSubject, key, tweak) {
 		modulus = assureBigInt(modulus);
 		const cipher = new FPEEncryptor(key, modulus, tweak);
-		const rounds = 3;
+		const rounds = this.getRound();
 		const [firstFactor, secondFactor] = factor(modulus);
 
 		let modulu;

--- a/lib/round.js
+++ b/lib/round.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = (function(_round) {
+  function getRound() { return _round; }
+
+  function setRound(round) {
+    if (round < 1 || !Number.isInteger(round)) {
+      throw Error('Parameter <round> must be a positive integer.');
+    }
+    _round = round;
+  }
+
+  return { getRound, setRound };
+}(3));

--- a/test/fe1.js
+++ b/test/fe1.js
@@ -17,11 +17,36 @@ describe('fe1 should', () => {
 	});
 
 	it('have the correct api', () => {
+		expect(api.getRound).to.be.a('function');
+		expect(api.setRound).to.be.a('function');
 		expect(api.encrypt).to.be.a('function');
 		expect(api.decrypt).to.be.a('function');
 	});
 
 	describe('work with native bindings and', () => {
+		it('default to 3 rounds', () => {
+			expect(api.getRound()).to.be.equal(3);
+		});
+
+		it('set round if parameter is positive int', () => {
+			api.setRound(4);
+			expect(api.getRound()).to.be.equal(4);
+			api.setRound(2);
+			api.setRound(2); // check repeat calls
+			expect(api.getRound()).to.be.equal(2);
+			api.setRound(3); // restore default
+		});
+
+		it('not set round if parameter is not positive or not int', () => {
+			expect(api.getRound()).to.be.equal(3);
+			expect(() => api.setRound(1.1)).to.throw(Error,
+				'Parameter <round> must be a positive integer.');
+			expect(api.getRound()).to.be.equal(3);
+			expect(() => api.setRound(0)).to.throw(Error,
+				'Parameter <round> must be a positive integer.');
+			expect(api.getRound()).to.be.equal(3);
+		});
+
 		it('encrypt and decrypt correctly with BigInt modulu', () => {
 			const EV = api.encrypt(bigIntModulus, subject, key, tweak);
 			const DV = api.decrypt(bigIntModulus, EV, key, tweak);


### PR DESCRIPTION
Convenience methods to allow user to set number of rounds for `encrypt` and `decrypt`.

- [x] Backward compatible.
- [x] Unit tests added.
- [x] Docs added (also tidied existing docs).

LMK if there are design issues; I tried to follow repo model.
Finally, a little confused on branching scheme. Please correct if `v1.0` is not the proper target.